### PR TITLE
[FE/Milo] - 라우터 구조 설계: 로그인, 메인, Outlet 포함한 뷰 구성 고려

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -11,6 +11,7 @@
         "immer": "^10.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.5.3",
         "styled-components": "^6.1.17",
         "zustand": "^5.0.4"
       },
@@ -4489,6 +4490,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.3.tgz",
+      "integrity": "sha512-3iUDM4/fZCQ89SXlDa+Ph3MevBrozBAI655OAfWQlTm9nBR0IKlrmNwFow5lPHttbwvITZfkeeeZFP6zt3F7pw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.5.3.tgz",
+      "integrity": "sha512-cK0jSaTyW4jV9SRKAItMIQfWZ/D6WEZafgHuuCb9g+SjhLolY78qc+De4w/Cz9ybjvLzShAmaIMEXt8iF1Cm+A==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.5.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4755,6 +4804,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5191,6 +5246,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -13,6 +13,7 @@
     "immer": "^10.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.5.3",
     "styled-components": "^6.1.17",
     "zustand": "^5.0.4"
   },

--- a/fe/src/routes/AppRouter.jsx
+++ b/fe/src/routes/AppRouter.jsx
@@ -1,0 +1,25 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
+export default function AppRouter() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* 로그인/회원가입은 레이아웃 없이 단독 페이지 */}
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signUp" element={<SignUpPage />} />
+
+        {/* 로그인된 유저만 접근 가능한 경로 */}
+        <Route element={<PrivateRoute />}>
+          <Route path="/" element={<MainLayout />}>
+            <Route index element={<IssueListPage />} />
+            <Route path="new" element={<NewIssuePage />} />
+            <Route path="labels" element={<LabelPage />} />
+            <Route path="milestones" element={<MilestonePage />} />
+            <Route path=":id" element={<IssueDetailPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Route>
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 로그인/회원가입 페이지는 MainLayout 없이 별도 라우트로 구성
- 인증된 사용자만 접근 가능한 라우트는 PrivateRoute로 보호
- 메인 페이지 이하의 모든 페이지는 MainLayout 하위에서 Outlet 구조로 렌더링
- NotFoundPage를 통해 잘못된 경로 처리

## 🔗 참조 자료
- [피그마 링크](https://www.figma.com/design/iCaxVg5GbJ3zdixryroKAU/WEB_%EC%9D%B4%EC%8A%88%ED%8A%B8%EB%9E%98%EC%BB%A4?node-id=29901-45818)
- [요구사항 문서](WEB_이슈트래커.pdf)

## 🎯 목표 결과
- 전체 요구사항 흐름을 충족하는 라우터 구조 완성
- 새로고침 없이 로그인 → 메인 → 상세/작성 페이지 전환 가능