### PR TITLE
[BE/MUD] JWT 토큰 반환 되지 않는 버그 수정

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/global/dto/BaseResponseDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/global/dto/BaseResponseDto.java
@@ -1,8 +1,10 @@
 package CodeSquad.IssueTracker.global.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BaseResponseDto<T> {

--- a/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
@@ -32,11 +32,11 @@ public class JWTUtil {
     /*
     JWT Access Token을 생성합니다.(페이로드에 유저 이름과 프로필 사진 링크 정보를 포함)
      */
-    public String createAccessToken(User loginUser, String imgUrl) {
+    public String createAccessToken(User loginUser) {
         return Jwts.builder()
                 .setSubject(loginUser.getLoginId())
                 .claim(CLAIM_LOGIN_ID, loginUser.getLoginId())
-                .claim(CLAIM_IMG_URL, imgUrl)
+                .claim(CLAIM_IMG_URL, loginUser.getProfileImageUrl())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION_TIME))
                 .signWith(Keys.hmacShaKeyFor(accessSecretKey.getBytes(UTF_8)))

--- a/be/src/main/java/CodeSquad/IssueTracker/login/service/LoginService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/login/service/LoginService.java
@@ -29,7 +29,7 @@ public class LoginService {
     public LoginResponseDto login(LoginRequestDto loginRequestDto) {
         User targetUser = getUser(loginRequestDto.getLoginId());
         validatePassword(targetUser, loginRequestDto.getPassword());
-        return generateToken(targetUser, "프로필 사진 URL");
+        return generateToken(targetUser);
     }
 
     private User getUser(String loginId) {
@@ -43,8 +43,8 @@ public class LoginService {
         }
     }
 
-    private LoginResponseDto generateToken(User targetUser, String imgUrl) {
-        String accessToken = jwtUtil.createAccessToken(targetUser, imgUrl);
+    private LoginResponseDto generateToken(User targetUser) {
+        String accessToken = jwtUtil.createAccessToken(targetUser);
         String refreshToken = jwtUtil.createRefreshToken();
         return new LoginResponseDto(accessToken, refreshToken);
     }

--- a/be/src/main/java/CodeSquad/IssueTracker/user/User.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/User.java
@@ -1,10 +1,16 @@
 package CodeSquad.IssueTracker.user;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table("users")
 public class User {
     @Id


### PR DESCRIPTION
## 문제
-BaseResponseDto 클래스에 @Getter가 없어 Jackson이 JSON 직렬화를 할 때 필드에 접근하지 못함
이로 인해 API 응답 시 직렬화 오류가 발생하여 응답 반환에 실패하는 문제가 있었음

## 해결
- BaseResponseDto에 @Getter 추가하여 Jackson 직렬화 문제 해결
- BaseResponseDto에 @Getter가 없어 JSON 직렬화 시 필드 접근이 안 되는 문제 수정
- 직렬화 오류로 인해 API 응답 반환 실패 문제 해결