### PR TITLE
[BE/MUD] 이슈 필터링 기능 구현

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
@@ -1,29 +1,20 @@
 package CodeSquad.IssueTracker.home;
 
+import CodeSquad.IssueTracker.global.dto.BaseResponseDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
-import CodeSquad.IssueTracker.issue.Issue;
-import CodeSquad.IssueTracker.issue.IssueService;
-import CodeSquad.IssueTracker.label.LabelService;
-import CodeSquad.IssueTracker.milestone.MilestoneService;
-import CodeSquad.IssueTracker.user.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/")
 public class HomeController {
 
     private final HomeService homeService;
 
     @GetMapping("/")
-    public HomeResponseDto home() {
-        return homeService.getHomeData();
+    public BaseResponseDto<HomeResponseDto> home(@ModelAttribute IssueFilterRequestDto filterRequestDto) {
+        return BaseResponseDto.success("이슈목록을 성공적으로 불러왔습니다.",
+                homeService.getHomeData(filterRequestDto));
     }
-
-
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
@@ -1,5 +1,6 @@
 package CodeSquad.IssueTracker.home;
 
+import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
 import CodeSquad.IssueTracker.issue.IssueService;
 import CodeSquad.IssueTracker.label.LabelService;
@@ -17,9 +18,9 @@ public class HomeService {
     private final MilestoneService milestoneService;
     private final UserService userService;
 
-    public HomeResponseDto getHomeData() {
+    public HomeResponseDto getHomeData(IssueFilterRequestDto filterRequestDto) {
         return new HomeResponseDto(
-                issueService.findAll(),
+                issueService.findIssuesByFilter(filterRequestDto),
                 labelService.findAll(),
                 milestoneService.findAll(),
                 userService.findAll()

--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
@@ -21,11 +21,9 @@ public class HomeService {
     public HomeResponseDto getHomeData(IssueFilterRequestDto filterRequestDto) {
         return new HomeResponseDto(
                 issueService.findIssuesByFilter(filterRequestDto),
+                userService.findAllUserDetails(),
                 labelService.findAll(),
-                milestoneService.findAll(),
-                userService.findAll()
+                milestoneService.findAll()
         );
     }
-
-
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
@@ -1,18 +1,16 @@
 package CodeSquad.IssueTracker.home.dto;
 
-import CodeSquad.IssueTracker.issue.Issue;
+import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.label.Label;
 import CodeSquad.IssueTracker.milestone.Milestone;
 import CodeSquad.IssueTracker.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 @AllArgsConstructor
 public class HomeResponseDto {
-    private Iterable<Issue> issues;
+    private Iterable<FilteredIssueDto> issues;
     private Iterable<Label> labels;
     private Iterable<Milestone> milestones;
     private Iterable<User> users;

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
@@ -3,7 +3,7 @@ package CodeSquad.IssueTracker.home.dto;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.label.Label;
 import CodeSquad.IssueTracker.milestone.Milestone;
-import CodeSquad.IssueTracker.user.User;
+import CodeSquad.IssueTracker.user.dto.DetailUserDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -11,7 +11,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class HomeResponseDto {
     private Iterable<FilteredIssueDto> issues;
+    private Iterable<DetailUserDto> users;
     private Iterable<Label> labels;
     private Iterable<Milestone> milestones;
-    private Iterable<User> users;
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/IssueFilterRequestDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/IssueFilterRequestDto.java
@@ -1,0 +1,15 @@
+package CodeSquad.IssueTracker.home.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class IssueFilterRequestDto {
+    private Boolean isOpen;
+    private Long label;
+    private Long assignee;
+    private Long author;
+    private Long milestone;
+    private Long commentedBy;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -1,5 +1,7 @@
 package CodeSquad.IssueTracker.issue;
 
+import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
 
 import java.util.List;
@@ -14,4 +16,6 @@ public interface IssueRepository {
     Optional<Issue> findById(Long issueId);
 
     List<Issue> findAll();
+
+    List<FilteredIssueDto> findIssuesByFilter(IssueFilterRequestDto filterRequestDto);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -7,8 +7,10 @@ import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueCreateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueDetailResponse;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
+import CodeSquad.IssueTracker.issueAssignee.IssueAssigneeRepository;
 import CodeSquad.IssueTracker.issueAssignee.IssueAssigneeService;
 import CodeSquad.IssueTracker.issueAssignee.dto.IssueAssigneeResponse;
+import CodeSquad.IssueTracker.issueLabel.IssueLabelRepository;
 import CodeSquad.IssueTracker.issueLabel.IssueLabelService;
 import CodeSquad.IssueTracker.issueLabel.dto.IssueLabelResponse;
 import CodeSquad.IssueTracker.milestone.MilestoneService;
@@ -30,6 +32,8 @@ import java.util.Optional;
 public class IssueService {
 
     private final IssueRepository issueRepository;
+    private final IssueAssigneeRepository issueAssigneeRepository;
+    private final IssueLabelRepository issueLabelRepository;
     private final IssueAssigneeService issueAssigneeService;
     private final IssueLabelService issueLabelService;
     private final UserService userService;
@@ -110,6 +114,13 @@ public class IssueService {
     }
 
     public Iterable<FilteredIssueDto> findIssuesByFilter(IssueFilterRequestDto filterRequestDto) {
-        return issueRepository.findIssuesByFilter(filterRequestDto);
+        List<FilteredIssueDto> issues = issueRepository.findIssuesByFilter(filterRequestDto);
+
+        for (FilteredIssueDto issue : issues) {
+            issue.setAssignees(issueAssigneeRepository.findSummaryAssigneeByIssueId(issue.getIssueId()));
+            issue.setLabels(issueLabelRepository.findSummaryLabelByIssueId(issue.getIssueId()));
+        }
+
+        return issues;
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -1,8 +1,9 @@
 package CodeSquad.IssueTracker.issue;
 
-import CodeSquad.IssueTracker.comment.Comment;
 import CodeSquad.IssueTracker.comment.CommentService;
 import CodeSquad.IssueTracker.comment.dto.CommentResponseDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueCreateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueDetailResponse;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
@@ -108,9 +109,7 @@ public class IssueService {
         return response;
     }
 
-
-
-
-
-
+    public Iterable<FilteredIssueDto> findIssuesByFilter(IssueFilterRequestDto filterRequestDto) {
+        return issueRepository.findIssuesByFilter(filterRequestDto);
+    }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -58,7 +58,7 @@ public class JdbcTemplateIssueRepository implements IssueRepository{
                 .addValue("content",updateParam.getContent())
                 .addValue("isOpen",updateParam.getIsOpen())
                 .addValue("timestamp",updateParam.getTimestamp())
-                .addValue("mildstondId",updateParam.getMilestoneId())
+                .addValue("milestoneId",updateParam.getMilestoneId())
                 .addValue("assigneeId",updateParam.getAssigneeId())
                 .addValue("id",issueId);
         template.update(sql, param);

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -23,10 +23,8 @@ import java.util.Map;
 import java.util.Optional;
 
 @Repository
-public class JdbcTemplateIssueRepository implements IssueRepository{
+public class JdbcTemplateIssueRepository implements IssueRepository {
 
-    private final IssueAssigneeRepository issueAssigneeRepository;
-    private final IssueLabelRepository issueLabelRepository;
     private final NamedParameterJdbcTemplate template;
     private final SimpleJdbcInsert jdbcInsert;
 
@@ -35,8 +33,6 @@ public class JdbcTemplateIssueRepository implements IssueRepository{
                                        IssueAssigneeRepository issueAssigneeRepository,
                                        IssueLabelRepository issueLabelRepository) {
         this.template = new NamedParameterJdbcTemplate(dataSource);
-        this.issueAssigneeRepository = issueAssigneeRepository;
-        this.issueLabelRepository = issueLabelRepository;
         this.jdbcInsert = new SimpleJdbcInsert(dataSource)
                 .withTableName("issues")
                 .usingGeneratedKeyColumns("id");
@@ -52,15 +48,15 @@ public class JdbcTemplateIssueRepository implements IssueRepository{
 
     @Override
     public void update(Long issueId, IssueUpdateDto updateParam) {
-        String sql = "UPDATE issues SET title = :title, content = :content, is_Open = :isOpen, timestamp = :timestamp, assignee_Id = :assigneeId, milestone_Id = :milestoneId WHERE id = :id" ;
+        String sql = "UPDATE issues SET title = :title, content = :content, is_Open = :isOpen, timestamp = :timestamp, assignee_Id = :assigneeId, milestone_Id = :milestoneId WHERE id = :id";
         SqlParameterSource param = new MapSqlParameterSource()
-                .addValue("title",updateParam.getTitle())
-                .addValue("content",updateParam.getContent())
-                .addValue("isOpen",updateParam.getIsOpen())
-                .addValue("timestamp",updateParam.getTimestamp())
-                .addValue("milestoneId",updateParam.getMilestoneId())
-                .addValue("assigneeId",updateParam.getAssigneeId())
-                .addValue("id",issueId);
+                .addValue("title", updateParam.getTitle())
+                .addValue("content", updateParam.getContent())
+                .addValue("isOpen", updateParam.getIsOpen())
+                .addValue("timestamp", updateParam.getTimestamp())
+                .addValue("milestoneId", updateParam.getMilestoneId())
+                .addValue("assigneeId", updateParam.getAssigneeId())
+                .addValue("id", issueId);
         template.update(sql, param);
     }
 
@@ -142,15 +138,10 @@ public class JdbcTemplateIssueRepository implements IssueRepository{
             return dto;
         });
 
-        for (FilteredIssueDto issue : issues) {
-            issue.setAssignees(issueAssigneeRepository.findSummaryAssigneeByIssueId(issue.getIssueId()));
-            issue.setLabels(issueLabelRepository.findSummaryLabelByIssueId(issue.getIssueId()));
-        }
-
         return issues;
     }
 
-    private RowMapper<Issue> issueRowMapper(){
+    private RowMapper<Issue> issueRowMapper() {
         return BeanPropertyRowMapper.newInstance(Issue.class);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/dto/FilteredIssueDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/dto/FilteredIssueDto.java
@@ -1,0 +1,23 @@
+package CodeSquad.IssueTracker.issue.dto;
+
+import CodeSquad.IssueTracker.issueLabel.dto.SummaryLabelDto;
+import CodeSquad.IssueTracker.milestone.dto.SummaryMilestoneDto;
+import CodeSquad.IssueTracker.user.dto.SummaryUserDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class FilteredIssueDto {
+    private Long issueId;
+    private String title;
+    private Boolean isOpen;
+    private SummaryUserDto author;
+    private List<SummaryUserDto> assignees;
+    private List<SummaryLabelDto> labels;
+    private SummaryMilestoneDto milestone;
+    private LocalDateTime lastModifiedAt;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/IssueAssigneeRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/IssueAssigneeRepository.java
@@ -1,5 +1,6 @@
 package CodeSquad.IssueTracker.issueAssignee;
 
+import CodeSquad.IssueTracker.user.dto.SummaryUserDto;
 import CodeSquad.IssueTracker.issueAssignee.dto.IssueAssigneeResponse;
 
 import java.util.List;
@@ -12,5 +13,5 @@ public interface IssueAssigneeRepository {
 
     List<IssueAssigneeResponse> findAssigneeResponsesByIssueId(Long issueId);
 
-
+    List<SummaryUserDto> findSummaryAssigneeByIssueId(Long issueId);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/JdbcTemplateAssigneeRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/JdbcTemplateAssigneeRepository.java
@@ -1,7 +1,9 @@
 package CodeSquad.IssueTracker.issueAssignee;
 
+import CodeSquad.IssueTracker.user.dto.SummaryUserDto;
 import CodeSquad.IssueTracker.issueAssignee.dto.IssueAssigneeResponse;
-import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -57,5 +59,15 @@ public class JdbcTemplateAssigneeRepository implements IssueAssigneeRepository {
                         rs.getString("profile_image_url")
                 )
         );
+    }
+
+    @Override
+    public List<SummaryUserDto> findSummaryAssigneeByIssueId(Long issueId) {
+        String sql = "SELECT u.id, u.nick_name FROM issue_assignee ia LEFT JOIN users u ON ia.assignee_id = u.id WHERE ia.issue_id = :issueId ";
+        return template.query(sql, Map.of("issueId", issueId), summaryUserRowMapper());
+    }
+
+    private RowMapper<SummaryUserDto> summaryUserRowMapper(){
+        return BeanPropertyRowMapper.newInstance(SummaryUserDto.class);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/IssueLabelRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/IssueLabelRepository.java
@@ -1,5 +1,6 @@
 package CodeSquad.IssueTracker.issueLabel;
 
+import CodeSquad.IssueTracker.issueLabel.dto.SummaryLabelDto;
 import CodeSquad.IssueTracker.issueLabel.dto.IssueLabelResponse;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface IssueLabelRepository {
     void deleteByIssueId(Long issueId);
 
     List<IssueLabelResponse> returnedIssueLabelResponsesByIssueId(Long issueId);
+
+    List<SummaryLabelDto> findSummaryLabelByIssueId(Long issueId);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
@@ -44,11 +44,11 @@ public class JdbcTemplateIssueLabelRepository implements IssueLabelRepository {
     public List<IssueLabelResponse> returnedIssueLabelResponsesByIssueId(Long issueId) {
         String sql = """
         SELECT
-            l.label_id,
-            l.name,
-            l.color
-        FROM issue_label il
-        JOIN labels l ON il.label_id = l.label_id
+            l.id AS label_id,
+            l.name AS name,
+            l.color AS color
+        FROM issue_labels il
+        JOIN labels l ON il.label_id = l.id
         WHERE il.issue_id = :issueId    
                 """;
 

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
@@ -1,6 +1,9 @@
 package CodeSquad.IssueTracker.issueLabel;
 
+import CodeSquad.IssueTracker.issueLabel.dto.SummaryLabelDto;
 import CodeSquad.IssueTracker.issueLabel.dto.IssueLabelResponse;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -56,5 +59,24 @@ public class JdbcTemplateIssueLabelRepository implements IssueLabelRepository {
                         rs.getString("color")
                 )
         );
+    }
+
+    @Override
+    public List<SummaryLabelDto> findSummaryLabelByIssueId(Long issueId) {
+        String sql = """
+            SELECT 
+                l.label_id, 
+                l.name, 
+                l.color 
+            FROM issue_label il 
+            LEFT JOIN labels l ON il.label_id = l.label_id
+            WHERE il.issue_id = :issueId    
+        """;
+
+        return template.query(sql, Map.of("issueId", issueId), summaryLabelDtoRowMapper());
+    }
+
+    private RowMapper<SummaryLabelDto> summaryLabelDtoRowMapper(){
+        return BeanPropertyRowMapper.newInstance(SummaryLabelDto.class);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
@@ -44,11 +44,11 @@ public class JdbcTemplateIssueLabelRepository implements IssueLabelRepository {
     public List<IssueLabelResponse> returnedIssueLabelResponsesByIssueId(Long issueId) {
         String sql = """
         SELECT
-            l.id AS label_id,
-            l.name AS name,
-            l.color AS color
-        FROM issue_labels il
-        JOIN labels l ON il.label_id = l.id
+            l.label_id,
+            l.name,
+            l.color
+        FROM issue_label il
+        JOIN labels l ON il.label_id = l.label_id
         WHERE il.issue_id = :issueId    
                 """;
 

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/dto/SummaryLabelDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/dto/SummaryLabelDto.java
@@ -1,0 +1,12 @@
+package CodeSquad.IssueTracker.issueLabel.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SummaryLabelDto {
+    private Long labelId;
+    private String name;
+    private String color;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
@@ -16,7 +16,7 @@ public class JWTUtil {
     private final String accessSecretKey;
     private final String refreshSecretKey;
     private static final String CLAIM_LOGIN_ID = "loginId";
-    private static final String CLAIM_IMG_URL = "imgUrl";
+    private static final String CLAIM_IMG_URL = "profileImageUrl";
 
     public JWTUtil(
             @Value("${spring.jwt.access-key}") String accessSecretKey,

--- a/be/src/main/java/CodeSquad/IssueTracker/milestone/dto/SummaryMilestoneDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/milestone/dto/SummaryMilestoneDto.java
@@ -1,0 +1,13 @@
+package CodeSquad.IssueTracker.milestone.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SummaryMilestoneDto {
+    private Long milestoneId;
+    private String name;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
@@ -1,5 +1,6 @@
 package CodeSquad.IssueTracker.user;
 
+import CodeSquad.IssueTracker.user.dto.DetailUserDto;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -57,6 +58,12 @@ public class JdbcTemplatesUserRepository implements UserRepository{
     }
 
     @Override
+    public List<DetailUserDto> findAllUserDetails() {
+        String sql = "SELECT id, nickname, img_url FROM users";
+        return template.query(sql, detailUserDtoRowMapper());
+    }
+
+    @Override
     public void deleteById(Long id) {
         String sql = "DELETE FROM users WHERE id = :id";
         Map<String, Object> param = Map.of("id", id);
@@ -65,5 +72,9 @@ public class JdbcTemplatesUserRepository implements UserRepository{
 
     private RowMapper<User> userRowMapper(){
         return BeanPropertyRowMapper.newInstance(User.class);
+    }
+
+    private RowMapper<DetailUserDto> detailUserDtoRowMapper(){
+        return BeanPropertyRowMapper.newInstance(DetailUserDto.class);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
@@ -59,7 +59,7 @@ public class JdbcTemplatesUserRepository implements UserRepository{
 
     @Override
     public List<DetailUserDto> findAllUserDetails() {
-        String sql = "SELECT id, nickname, img_url FROM users";
+        String sql = "SELECT id, nick_name, img_url FROM users";
         return template.query(sql, detailUserDtoRowMapper());
     }
 

--- a/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/JdbcTemplatesUserRepository.java
@@ -59,7 +59,7 @@ public class JdbcTemplatesUserRepository implements UserRepository{
 
     @Override
     public List<DetailUserDto> findAllUserDetails() {
-        String sql = "SELECT id, nick_name, img_url FROM users";
+        String sql = "SELECT id, nick_name, profile_image_url FROM users";
         return template.query(sql, detailUserDtoRowMapper());
     }
 

--- a/be/src/main/java/CodeSquad/IssueTracker/user/UserRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/UserRepository.java
@@ -1,5 +1,7 @@
 package CodeSquad.IssueTracker.user;
 
+import CodeSquad.IssueTracker.user.dto.DetailUserDto;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -13,6 +15,7 @@ public interface UserRepository {
 
     List<User> findAll();
 
-    void deleteById(Long id);
+    List<DetailUserDto> findAllUserDetails();
 
+    void deleteById(Long id);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/user/UserService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/UserService.java
@@ -1,5 +1,6 @@
 package CodeSquad.IssueTracker.user;
 
+import CodeSquad.IssueTracker.user.dto.DetailUserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -29,5 +30,9 @@ public class UserService {
 
     public void deleteById(Long id) {
         userRepository.deleteById(id);
+    }
+
+    public Iterable<DetailUserDto> findAllUserDetails() {
+        return userRepository.findAllUserDetails();
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/user/dto/DetailUserDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/dto/DetailUserDto.java
@@ -1,0 +1,16 @@
+package CodeSquad.IssueTracker.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DetailUserDto {
+    private Long id;
+    private String nickname;
+    private String imgUrl;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/user/dto/DetailUserDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/dto/DetailUserDto.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class DetailUserDto {
     private Long id;
-    private String nickname;
-    private String imgUrl;
+    private String nickName;
+    private String profileImageUrl;
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/user/dto/SummaryUserDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/user/dto/SummaryUserDto.java
@@ -1,0 +1,15 @@
+package CodeSquad.IssueTracker.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SummaryUserDto {
+    private Long id;
+    private String nickName;
+}


### PR DESCRIPTION
## 💡 관련 이슈
close: #51 

## 🎉 작업 사항
- 이슈 필터링 기능 구현

## 📌 PR Point
**이슈 필터링 기능 구현**

이번에는 Spring Data JDBC 기반으로 이슈 목록을 다양한 조건으로 필터링하는 기능을 구현했습니다. 
클라이언트가 요청한 열림/닫힘 상태, 작성자, 마일스톤, 레이블, 담당자 등의 필터 조건에 따라 동적으로 SQL 쿼리를 생성하여, 필요한 이슈만 조회할 수 있도록 했습니다. 
이를 위해 여러 테이블(users, milestones, issue_assignee, issue_label)을 조인하여 이슈에 필요한 모든 정보를 한 번에 가져오도록 구현했습니다.

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?
