### PR TITLE
[BE/MUD] - 댓글 남긴 이슈 필터링 기능 구현

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -82,7 +82,8 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
                 .append("LEFT JOIN milestones m ON i.milestone_id = m.milestone_id\n")
                 .append("LEFT JOIN users u ON i.author_id = u.id\n")
                 .append("LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id\n")
-                .append("LEFT JOIN issue_label il ON i.issue_id = il.issue_id\n");
+                .append("LEFT JOIN issue_label il ON i.issue_id = il.issue_id\n")
+                .append("LEFT JOIN comments c ON i.issue_id = c.issue_id\n");
 
         boolean hasWhere = false;
         MapSqlParameterSource params = new MapSqlParameterSource();
@@ -125,6 +126,13 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
             issueSql.append("ia.assignee_id = :assigneeId");
             params.addValue("assigneeId", filterRequestDto.getAssignee());
             hasWhere = true;
+        }
+
+        // 댓글 남긴 이슈 필터링
+        if (filterRequestDto.getCommentedBy() != null) {
+            issueSql.append(hasWhere ? "AND " : "WHERE ");
+            issueSql.append("c.author_id = :commentedBy");
+            params.addValue("commentedBy", filterRequestDto.getCommentedBy());
         }
 
         List<FilteredIssueDto> issues = template.query(issueSql.toString(), params, (rs, rowNum) -> {


### PR DESCRIPTION
## 💡 관련 이슈
close: #92  

## 🎉 작업 사항
- 댓글 남긴 이슈 필터링 기능 구현

## 📌 PR Point
**댓글 남긴 이슈 필터링 기능 구현**
- LEFT JOIN comments를 통해 댓글 작성자 정보와 이슈를 연동
- filterRequestDto.getCommentedBy()를 조건에 포함시켜, 해당 사용자가 댓글을 남긴 이슈만 조회되도록 구현
- 기존 필터 조건들과 충돌 없이 동작하도록 WHERE 조건 분기 처리 추가

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?
