### PR TITLE
[BE/MUD] - 이슈 목록 페이지 네이션 구현 및 필터링 로직 리팩토링

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
@@ -13,8 +13,8 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping("/")
-    public BaseResponseDto<HomeResponseDto> home(@ModelAttribute IssueFilterRequestDto filterRequestDto) {
+    public BaseResponseDto<HomeResponseDto> home(@RequestParam int page, @ModelAttribute IssueFilterRequestDto filterRequestDto) {
         return BaseResponseDto.success("이슈목록을 성공적으로 불러왔습니다.",
-                homeService.getHomeData(filterRequestDto));
+                homeService.getHomeData(page, filterRequestDto));
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
@@ -1,7 +1,7 @@
 package CodeSquad.IssueTracker.home;
 
 import CodeSquad.IssueTracker.global.dto.BaseResponseDto;
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -13,8 +13,8 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping("/")
-    public BaseResponseDto<HomeResponseDto> home(@RequestParam int page, @ModelAttribute IssueFilterRequestDto filterRequestDto) {
+    public BaseResponseDto<HomeResponseDto> home(@RequestParam int page, @ModelAttribute IssueFilterCondition condition) {
         return BaseResponseDto.success("이슈목록을 성공적으로 불러왔습니다.",
-                homeService.getHomeData(page, filterRequestDto));
+                homeService.getHomeData(page, condition));
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
@@ -2,6 +2,7 @@ package CodeSquad.IssueTracker.home;
 
 import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
+import CodeSquad.IssueTracker.home.dto.MetaData;
 import CodeSquad.IssueTracker.issue.IssueService;
 import CodeSquad.IssueTracker.label.LabelService;
 import CodeSquad.IssueTracker.milestone.MilestoneService;
@@ -18,12 +19,16 @@ public class HomeService {
     private final MilestoneService milestoneService;
     private final UserService userService;
 
-    public HomeResponseDto getHomeData(IssueFilterRequestDto filterRequestDto) {
+    public HomeResponseDto getHomeData(int currentPage, IssueFilterRequestDto filterRequestDto) {
+        int openIssueNumber = issueService.countIssuesByOpenStatus(true, filterRequestDto);
+        int closeIssueNumber = issueService.countIssuesByOpenStatus(false, filterRequestDto);
+        int maxPage = issueService.getIssueMaxPage(filterRequestDto);
         return new HomeResponseDto(
-                issueService.findIssuesByFilter(filterRequestDto),
+                issueService.findIssuesByFilter(currentPage, filterRequestDto),
                 userService.findAllUserDetails(),
                 labelService.findAll(),
-                milestoneService.findAll()
+                milestoneService.findAll(),
+                new MetaData(currentPage, maxPage, openIssueNumber, closeIssueNumber)
         );
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeService.java
@@ -1,6 +1,6 @@
 package CodeSquad.IssueTracker.home;
 
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
 import CodeSquad.IssueTracker.home.dto.MetaData;
 import CodeSquad.IssueTracker.issue.IssueService;
@@ -19,12 +19,12 @@ public class HomeService {
     private final MilestoneService milestoneService;
     private final UserService userService;
 
-    public HomeResponseDto getHomeData(int currentPage, IssueFilterRequestDto filterRequestDto) {
-        int openIssueNumber = issueService.countIssuesByOpenStatus(true, filterRequestDto);
-        int closeIssueNumber = issueService.countIssuesByOpenStatus(false, filterRequestDto);
-        int maxPage = issueService.getIssueMaxPage(filterRequestDto);
+    public HomeResponseDto getHomeData(int currentPage, IssueFilterCondition condition) {
+        int openIssueNumber = issueService.countIssuesByOpenStatus(true, condition);
+        int closeIssueNumber = issueService.countIssuesByOpenStatus(false, condition);
+        int maxPage = issueService.getIssueMaxPage(condition);
         return new HomeResponseDto(
-                issueService.findIssuesByFilter(currentPage, filterRequestDto),
+                issueService.findIssuesByFilter(currentPage, condition),
                 userService.findAllUserDetails(),
                 labelService.findAll(),
                 milestoneService.findAll(),

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
@@ -14,4 +14,5 @@ public class HomeResponseDto {
     private Iterable<DetailUserDto> users;
     private Iterable<Label> labels;
     private Iterable<Milestone> milestones;
+    private MetaData meta;
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/IssueFilterCondition.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/IssueFilterCondition.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class IssueFilterRequestDto {
+public class IssueFilterCondition {
     private Boolean isOpen;
     private Long label;
     private Long assignee;

--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/MetaData.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/MetaData.java
@@ -1,0 +1,13 @@
+package CodeSquad.IssueTracker.home.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MetaData {
+    private final int currentPage;
+    private final int maxPage;
+    private final int openIssueNumber;
+    private final int closeIssueNumber;
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueFilterQueryBuilder.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueFilterQueryBuilder.java
@@ -1,0 +1,52 @@
+package CodeSquad.IssueTracker.issue;
+
+import lombok.Getter;
+import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+@Getter
+public class IssueFilterQueryBuilder {
+
+    private final StringBuilder whereClause = new StringBuilder();
+    private final MapSqlParameterSource params = new MapSqlParameterSource();
+
+    public IssueFilterQueryBuilder(Boolean isOpen, IssueFilterRequestDto filter) {
+        whereClause.append(" WHERE 1=1 ");
+
+        // 이슈 열림/닫힘 필터링
+        if (isOpen != null) {
+            whereClause.append("AND i.is_open = :isOpen ");
+            params.addValue("isOpen", isOpen);
+        }
+
+        // 작성자 필터링
+        if (filter.getAuthor() != null) {
+            whereClause.append("AND i.author_id = :authorId ");
+            params.addValue("authorId", filter.getAuthor());
+        }
+
+        // 마일스톤 필터링
+        if (filter.getMilestone() != null) {
+            whereClause.append("AND i.milestone_id = :milestoneId ");
+            params.addValue("milestoneId", filter.getMilestone());
+        }
+
+        // 레이블 필터링
+        if (filter.getLabel() != null) {
+            whereClause.append("AND il.label_id = :labelId ");
+            params.addValue("labelId", filter.getLabel());
+        }
+
+        // 담당자 필터링
+        if (filter.getAssignee() != null) {
+            whereClause.append("AND ia.assignee_id = :assigneeId ");
+            params.addValue("assigneeId", filter.getAssignee());
+        }
+
+        // 댓글 남긴 이슈 필터링
+        if (filter.getCommentedBy() != null) {
+            whereClause.append("AND c.author_id = :commentedBy ");
+            params.addValue("commentedBy", filter.getCommentedBy());
+        }
+    }
+}

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueFilterQueryBuilder.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueFilterQueryBuilder.java
@@ -1,7 +1,7 @@
 package CodeSquad.IssueTracker.issue;
 
 import lombok.Getter;
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 @Getter
@@ -10,7 +10,7 @@ public class IssueFilterQueryBuilder {
     private final StringBuilder whereClause = new StringBuilder();
     private final MapSqlParameterSource params = new MapSqlParameterSource();
 
-    public IssueFilterQueryBuilder(Boolean isOpen, IssueFilterRequestDto filter) {
+    public IssueFilterQueryBuilder(Boolean isOpen, IssueFilterCondition condition) {
         whereClause.append(" WHERE 1=1 ");
 
         // 이슈 열림/닫힘 필터링
@@ -20,33 +20,33 @@ public class IssueFilterQueryBuilder {
         }
 
         // 작성자 필터링
-        if (filter.getAuthor() != null) {
+        if (condition.getAuthor() != null) {
             whereClause.append("AND i.author_id = :authorId ");
-            params.addValue("authorId", filter.getAuthor());
+            params.addValue("authorId", condition.getAuthor());
         }
 
         // 마일스톤 필터링
-        if (filter.getMilestone() != null) {
+        if (condition.getMilestone() != null) {
             whereClause.append("AND i.milestone_id = :milestoneId ");
-            params.addValue("milestoneId", filter.getMilestone());
+            params.addValue("milestoneId", condition.getMilestone());
         }
 
         // 레이블 필터링
-        if (filter.getLabel() != null) {
+        if (condition.getLabel() != null) {
             whereClause.append("AND il.label_id = :labelId ");
-            params.addValue("labelId", filter.getLabel());
+            params.addValue("labelId", condition.getLabel());
         }
 
         // 담당자 필터링
-        if (filter.getAssignee() != null) {
+        if (condition.getAssignee() != null) {
             whereClause.append("AND ia.assignee_id = :assigneeId ");
-            params.addValue("assigneeId", filter.getAssignee());
+            params.addValue("assigneeId", condition.getAssignee());
         }
 
         // 댓글 남긴 이슈 필터링
-        if (filter.getCommentedBy() != null) {
+        if (condition.getCommentedBy() != null) {
             whereClause.append("AND c.author_id = :commentedBy ");
-            params.addValue("commentedBy", filter.getCommentedBy());
+            params.addValue("commentedBy", condition.getCommentedBy());
         }
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -18,4 +18,6 @@ public interface IssueRepository {
     List<Issue> findAll();
 
     List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto);
+
+    int countFilteredIssues(IssueFilterRequestDto filterRequestDto);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -17,5 +17,5 @@ public interface IssueRepository {
 
     List<Issue> findAll();
 
-    List<FilteredIssueDto> findIssuesByFilter(IssueFilterRequestDto filterRequestDto);
+    List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -19,5 +19,5 @@ public interface IssueRepository {
 
     List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto);
 
-    int countFilteredIssues(IssueFilterRequestDto filterRequestDto);
+    int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filterRequestDto);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -1,6 +1,6 @@
 package CodeSquad.IssueTracker.issue;
 
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
 
@@ -17,7 +17,7 @@ public interface IssueRepository {
 
     List<Issue> findAll();
 
-    List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto);
+    List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterCondition condition);
 
-    int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filterRequestDto);
+    int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterCondition condition);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -2,7 +2,7 @@ package CodeSquad.IssueTracker.issue;
 
 import CodeSquad.IssueTracker.comment.CommentService;
 import CodeSquad.IssueTracker.comment.dto.CommentResponseDto;
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueCreateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueDetailResponse;
@@ -115,8 +115,8 @@ public class IssueService {
         return response;
     }
 
-    public Iterable<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto) {
-        List<FilteredIssueDto> issues = issueRepository.findIssuesByFilter(page, filterRequestDto);
+    public Iterable<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterCondition condition) {
+        List<FilteredIssueDto> issues = issueRepository.findIssuesByFilter(page, condition);
 
         for (FilteredIssueDto issue : issues) {
             issue.setAssignees(issueAssigneeRepository.findSummaryAssigneeByIssueId(issue.getIssueId()));
@@ -126,12 +126,12 @@ public class IssueService {
         return issues;
     }
 
-    public int getIssueMaxPage(IssueFilterRequestDto filterRequestDto) {
-        int totalCount =  issueRepository.countFilteredIssuesByIsOpen(filterRequestDto.getIsOpen(), filterRequestDto);
+    public int getIssueMaxPage(IssueFilterCondition condition) {
+        int totalCount =  issueRepository.countFilteredIssuesByIsOpen(condition.getIsOpen(), condition);
         return  (int) Math.ceil((double) totalCount / LIMIT_SIZE);
     }
 
-    public int countIssuesByOpenStatus(boolean isOpen, IssueFilterRequestDto filterRequestDto) {
-        return issueRepository.countFilteredIssuesByIsOpen(isOpen, filterRequestDto);
+    public int countIssuesByOpenStatus(boolean isOpen, IssueFilterCondition condition) {
+        return issueRepository.countFilteredIssuesByIsOpen(isOpen, condition);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -31,6 +31,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class IssueService {
 
+    public static final int LIMIT_SIZE = 20;
+
     private final IssueRepository issueRepository;
     private final IssueAssigneeRepository issueAssigneeRepository;
     private final IssueLabelRepository issueLabelRepository;
@@ -113,8 +115,8 @@ public class IssueService {
         return response;
     }
 
-    public Iterable<FilteredIssueDto> findIssuesByFilter(IssueFilterRequestDto filterRequestDto) {
-        List<FilteredIssueDto> issues = issueRepository.findIssuesByFilter(filterRequestDto);
+    public Iterable<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto) {
+        List<FilteredIssueDto> issues = issueRepository.findIssuesByFilter(page, filterRequestDto);
 
         for (FilteredIssueDto issue : issues) {
             issue.setAssignees(issueAssigneeRepository.findSummaryAssigneeByIssueId(issue.getIssueId()));
@@ -122,5 +124,10 @@ public class IssueService {
         }
 
         return issues;
+    }
+
+    public int getIssueMaxPage(IssueFilterRequestDto filterRequestDto) {
+        int totalCount =  issueRepository.countFilteredIssues(filterRequestDto);
+        return  (int) Math.ceil((double) totalCount / LIMIT_SIZE);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -127,7 +127,7 @@ public class IssueService {
     }
 
     public int getIssueMaxPage(IssueFilterRequestDto filterRequestDto) {
-        int totalCount =  issueRepository.countFilteredIssues(filterRequestDto);
+        int totalCount =  issueRepository.countFilteredIssuesByIsOpen(filterRequestDto.getIsOpen(), filterRequestDto);
         return  (int) Math.ceil((double) totalCount / LIMIT_SIZE);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -130,4 +130,8 @@ public class IssueService {
         int totalCount =  issueRepository.countFilteredIssuesByIsOpen(filterRequestDto.getIsOpen(), filterRequestDto);
         return  (int) Math.ceil((double) totalCount / LIMIT_SIZE);
     }
+
+    public int countIssuesByOpenStatus(boolean isOpen, IssueFilterRequestDto filterRequestDto) {
+        return issueRepository.countFilteredIssuesByIsOpen(isOpen, filterRequestDto);
+    }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -151,9 +151,9 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
     }
 
     @Override
-    public int countFilteredIssues(IssueFilterRequestDto filterRequestDto) {
+    public int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filterRequestDto) {
         StringBuilder countSql = new StringBuilder();
-        countSql.append("SELECT COUNT(DISTINCT i.issue_id) ")  // DISTINCT로 중복 제거
+        countSql.append("SELECT COUNT(DISTINCT i.issue_id) ")
                 .append("FROM issues i ")
                 .append("LEFT JOIN milestones m ON i.milestone_id = m.milestone_id ")
                 .append("LEFT JOIN users u ON i.author_id = u.id ")
@@ -168,7 +168,7 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
         if (filterRequestDto.getIsOpen() != null) {
             countSql.append("WHERE ");
             countSql.append("i.is_open = :isOpen ");
-            params.addValue("isOpen", filterRequestDto.getIsOpen());
+            params.addValue("isOpen", isOpen);
             hasWhere = true;
         }
 
@@ -213,7 +213,6 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
 
         return template.queryForObject(countSql.toString(), params, Integer.class);
     }
-
 
     private RowMapper<Issue> issueRowMapper() {
         return BeanPropertyRowMapper.newInstance(Issue.class);

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -71,72 +71,26 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
     }
 
     @Override
-    public List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filterRequestDto) {
-        StringBuilder issueSql = new StringBuilder();
-        issueSql.append("SELECT DISTINCT i.issue_id, i.title, i.is_open, i.author_id, u.nick_name, i.milestone_id, m.name AS milestone_name, i.last_modified_at\n")
-                .append("FROM issues i\n")
-                .append("LEFT JOIN milestones m ON i.milestone_id = m.milestone_id\n")
-                .append("LEFT JOIN users u ON i.author_id = u.id\n")
-                .append("LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id\n")
-                .append("LEFT JOIN issue_label il ON i.issue_id = il.issue_id\n")
-                .append("LEFT JOIN comments c ON i.issue_id = c.issue_id\n");
+    public List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filter) {
+        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(filter.getIsOpen(), filter);
+        String sql = """
+            SELECT DISTINCT
+            i.issue_id, i.title, i.is_open, i.author_id, u.nick_name, i.milestone_id, m.name AS milestone_name, i.last_modified_at
+            FROM issues i
+            LEFT JOIN milestones m ON i.milestone_id = m.milestone_id
+            LEFT JOIN users u ON i.author_id = u.id
+            LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id
+            LEFT JOIN issue_label il ON i.issue_id = il.issue_id
+            LEFT JOIN comments c ON i.issue_id = c.issue_id
+         """ + queryBuilder.getWhereClause() + """
+            ORDER BY i.issue_id DESC LIMIT :limit OFFSET :page
+         """;
 
-        boolean hasWhere = false;
-        MapSqlParameterSource params = new MapSqlParameterSource();
-
-        // 이슈 열림/닫힘 상태 필터링
-        if (filterRequestDto.getIsOpen() != null) {
-            issueSql.append("WHERE ");
-            issueSql.append("i.is_open = :isOpen ");
-            params.addValue("isOpen", filterRequestDto.getIsOpen());
-            hasWhere = true;
-        }
-
-        // 작성자 필터링
-        if (filterRequestDto.getAuthor() != null) {
-            issueSql.append(hasWhere ? "AND " : "WHERE ");
-            issueSql.append("i.author_id = :authorId ");
-            params.addValue("authorId", filterRequestDto.getAuthor());
-            hasWhere = true;
-        }
-
-        // 마일스톤 필터링
-        if (filterRequestDto.getMilestone() != null) {
-            issueSql.append(hasWhere ? "AND " : "WHERE ");
-            issueSql.append("i.milestone_id = :milestoneId");
-            params.addValue("milestoneId", filterRequestDto.getMilestone());
-            hasWhere = true;
-        }
-
-        // 레이블 필터링
-        if (filterRequestDto.getLabel() != null) {
-            issueSql.append(hasWhere ? "AND " : "WHERE ");
-            issueSql.append("il.label_id = :labelId");
-            params.addValue("labelId", filterRequestDto.getLabel());
-            hasWhere = true;
-        }
-
-        // 담당자 필터링
-        if (filterRequestDto.getAssignee() != null) {
-            issueSql.append(hasWhere ? "AND " : "WHERE ");
-            issueSql.append("ia.assignee_id = :assigneeId");
-            params.addValue("assigneeId", filterRequestDto.getAssignee());
-            hasWhere = true;
-        }
-
-        // 댓글 남긴 이슈 필터링
-        if (filterRequestDto.getCommentedBy() != null) {
-            issueSql.append(hasWhere ? "AND " : "WHERE ");
-            issueSql.append("c.author_id = :commentedBy");
-            params.addValue("commentedBy", filterRequestDto.getCommentedBy());
-        }
-
-        issueSql.append(" ORDER BY i.issue_id DESC\n");
-        issueSql.append("LIMIT :limitSize OFFSET :page");
-        params.addValue("limitSize", LIMIT_SIZE);
+        MapSqlParameterSource params = queryBuilder.getParams();
+        params.addValue("limit", LIMIT_SIZE);
         params.addValue("page", (page - 1) * LIMIT_SIZE);
 
-        List<FilteredIssueDto> issues = template.query(issueSql.toString(), params, (rs, rowNum) -> {
+        return template.query(sql.toString(), params, (rs, rowNum) -> {
             FilteredIssueDto dto = new FilteredIssueDto();
             dto.setIssueId(rs.getLong("issue_id"));
             dto.setTitle(rs.getString("title"));
@@ -146,72 +100,25 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
             dto.setLastModifiedAt(rs.getTimestamp("last_modified_at").toLocalDateTime());
             return dto;
         });
-
-        return issues;
     }
 
     @Override
-    public int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filterRequestDto) {
-        StringBuilder countSql = new StringBuilder();
-        countSql.append("SELECT COUNT(DISTINCT i.issue_id) ")
-                .append("FROM issues i ")
-                .append("LEFT JOIN milestones m ON i.milestone_id = m.milestone_id ")
-                .append("LEFT JOIN users u ON i.author_id = u.id ")
-                .append("LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id ")
-                .append("LEFT JOIN issue_label il ON i.issue_id = il.issue_id ")
-                .append("LEFT JOIN comments c ON i.issue_id = c.issue_id ");
+    public int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filter) {
+        String countSql = """
+            SELECT COUNT(DISTINCT i.issue_id)
+            FROM issues i
+            LEFT JOIN milestones m ON i.milestone_id = m.milestone_id
+            LEFT JOIN users u ON i.author_id = u.id
+            LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id
+            LEFT JOIN issue_label il ON i.issue_id = il.issue_id
+            LEFT JOIN comments c ON i.issue_id = c.issue_id
+            """;
 
-        boolean hasWhere = false;
-        MapSqlParameterSource params = new MapSqlParameterSource();
+        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(isOpen, filter);
+        String whereClause = queryBuilder.getWhereClause().toString();
+        String finalSql = countSql + whereClause;
 
-        // 이슈 열림/닫힘 상태 필터링
-        if (filterRequestDto.getIsOpen() != null) {
-            countSql.append("WHERE ");
-            countSql.append("i.is_open = :isOpen ");
-            params.addValue("isOpen", isOpen);
-            hasWhere = true;
-        }
-
-        // 작성자 필터링
-        if (filterRequestDto.getAuthor() != null) {
-            countSql.append(hasWhere ? "AND " : "WHERE ");
-            countSql.append("i.author_id = :authorId ");
-            params.addValue("authorId", filterRequestDto.getAuthor());
-            hasWhere = true;
-        }
-
-        // 마일스톤 필터링
-        if (filterRequestDto.getMilestone() != null) {
-            countSql.append(hasWhere ? "AND " : "WHERE ");
-            countSql.append("i.milestone_id = :milestoneId");
-            params.addValue("milestoneId", filterRequestDto.getMilestone());
-            hasWhere = true;
-        }
-
-        // 레이블 필터링
-        if (filterRequestDto.getLabel() != null) {
-            countSql.append(hasWhere ? "AND " : "WHERE ");
-            countSql.append("il.label_id = :labelId");
-            params.addValue("labelId", filterRequestDto.getLabel());
-            hasWhere = true;
-        }
-
-        // 담당자 필터링
-        if (filterRequestDto.getAssignee() != null) {
-            countSql.append(hasWhere ? "AND " : "WHERE ");
-            countSql.append("ia.assignee_id = :assigneeId");
-            params.addValue("assigneeId", filterRequestDto.getAssignee());
-            hasWhere = true;
-        }
-
-        // 댓글 남긴 이슈 필터링
-        if (filterRequestDto.getCommentedBy() != null) {
-            countSql.append(hasWhere ? "AND " : "WHERE ");
-            countSql.append("c.author_id = :commentedBy");
-            params.addValue("commentedBy", filterRequestDto.getCommentedBy());
-        }
-
-        return template.queryForObject(countSql.toString(), params, Integer.class);
+        return template.queryForObject(finalSql, queryBuilder.getParams(), Integer.class);
     }
 
     private RowMapper<Issue> issueRowMapper() {

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -1,6 +1,6 @@
 package CodeSquad.IssueTracker.issue;
 
-import CodeSquad.IssueTracker.home.dto.IssueFilterRequestDto;
+import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
 import CodeSquad.IssueTracker.milestone.dto.SummaryMilestoneDto;
@@ -71,8 +71,8 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
     }
 
     @Override
-    public List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterRequestDto filter) {
-        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(filter.getIsOpen(), filter);
+    public List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterCondition condition) {
+        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(condition.getIsOpen(), condition);
         String sql = """
             SELECT DISTINCT
             i.issue_id, i.title, i.is_open, i.author_id, u.nick_name, i.milestone_id, m.name AS milestone_name, i.last_modified_at
@@ -103,7 +103,7 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
     }
 
     @Override
-    public int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterRequestDto filter) {
+    public int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterCondition condition) {
         String countSql = """
             SELECT COUNT(DISTINCT i.issue_id)
             FROM issues i
@@ -114,7 +114,7 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
             LEFT JOIN comments c ON i.issue_id = c.issue_id
             """;
 
-        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(isOpen, filter);
+        IssueFilterQueryBuilder queryBuilder = new IssueFilterQueryBuilder(isOpen, condition);
         String whereClause = queryBuilder.getWhereClause().toString();
         String finalSql = countSql + whereClause;
 


### PR DESCRIPTION
## 💡 관련 이슈
close: #94 

## 🎉 작업 사항
- 이슈 목록 페이지네이션 기능 구현
- 필터링 로직 리팩토링

## 📌 PR Point

### 이슈 목록 페이지네이션
- SQL의 `LIMIT`, `OFFSET`을 활용해 20개 단위로 이슈 목록을 페이지네이션 하도록 구현했습니다.
- 클라이언트에는 현재 페이지, 전체 페이지 수, 열린 이슈 수, 닫힌 이슈 수의 정보를 `MetaData` 객체에 담아 함께 응답합니다.

### 필터링 로직 개선
- 이슈 목록 조회뿐만 아니라, 열린/닫힌 이슈 수를 집계할 때도 동일한 필터링 로직이 사용됩니다.
- 이를 위해 필터 조건 생성을 `IssueFilterQueryBuilder` 클래스로 분리하여, 재사용성을 높이고 `JdbcTemplateIssueRepository`의 가독성도 개선했습니다.

## 📝 셀프체크리스트
- [x] 머지하려고 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?