### PR TITLE
[BE/MUD] JWT 토큰에 사용자 ID 누락으로 발생한 이슈 필터링 오류 수정 

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/jwt/util/JWTUtil.java
@@ -16,6 +16,7 @@ public class JWTUtil {
     private final String accessSecretKey;
     private final String refreshSecretKey;
     private static final String CLAIM_LOGIN_ID = "loginId";
+    private static final String CLAIM_LOGIN_USER = "loginUser";
     private static final String CLAIM_IMG_URL = "profileImageUrl";
 
     public JWTUtil(
@@ -34,8 +35,8 @@ public class JWTUtil {
      */
     public String createAccessToken(User loginUser) {
         return Jwts.builder()
-                .setSubject(loginUser.getLoginId())
-                .claim(CLAIM_LOGIN_ID, loginUser.getLoginId())
+                .claim(CLAIM_LOGIN_ID, loginUser.getId()) // 사용자의 식별자 id
+                .claim(CLAIM_LOGIN_USER, loginUser.getLoginId()) // 로그인 시 사용되는 id
                 .claim(CLAIM_IMG_URL, loginUser.getProfileImageUrl())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRATION_TIME))


### PR DESCRIPTION
## 💡 관련 이슈
close: #100 

## 🎉 작업 사항
- 내가 작성한 이슈, 나에게 할당된 이슈, 내가 댓글 남긴 이슈 필터링 시 발생하는 오류 해결

## 📌 PR Point
JWT 토큰의 로그인 사용자 정보를 기반으로 이슈를 필터링할 때,  
**식별자 ID**가 아닌 **로그인 아이디**를 기준으로 필터링 요청을 보내어 **타입 불일치 오류**가 발생했습니다.

### ✅ 올바른 요청 예시
```
/?page=1&isOpen=true&assignee=1
```

### ❌ 잘못된 요청 예시
```
/?page=1&isOpen=true&assignee=admin@example.com
```

JWT Payload를 확인한 결과, 아래와 같이 **식별자 ID가 포함되지 않은 상태**였습니다:

```json
{
  "sub": "admin@example.com",
  "loginId": "admin@example.com",
  "profileImageUrl": "https://dummy.local/profile/admin.png",
  "iat": 1748332771,
  "exp": 1748419171
}
```

이에 따라 JWT 토큰 생성 시 사용자 식별자 ID와 로그인 아이디를 모두 포함하도록 수정하여
이슈 필터링 요청 시 올바른 ID가 전달되도록 하였습니다.

## 📝 셀프체크리스트
- [x] 머지하려고 하는 브랜치가 올바른가?
- [x] 코딩컨벤션을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?