### PR TITLE
[BE/MUD] - 페이지네이션 메타데이터 필드명 불일치 오류 해결

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/dto/HomeResponseDto.java
@@ -14,5 +14,5 @@ public class HomeResponseDto {
     private Iterable<DetailUserDto> users;
     private Iterable<Label> labels;
     private Iterable<Milestone> milestones;
-    private MetaData meta;
+    private MetaData metaData;
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close: #104 

## 🎉 작업 사항
- 메타데이터 필드명을 meta → metaData로 수정하여 페이지네이션 오류 해결
## 📌 PR Point
- 클라이언트에서 기대하는 metaData 키에 맞추어 서버 응답 필드명을 수정
- HomeResponseDto 내 meta → metaData 변경
- 클라이언트 페이지네이션 정상 작동 확인을 위한 테스트 완료

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?
