### PR TITLE
[BE/MUD] - 다중 이슈 상태 변경 기능 구현

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/home/HomeController.java
@@ -3,6 +3,8 @@ package CodeSquad.IssueTracker.home;
 import CodeSquad.IssueTracker.global.dto.BaseResponseDto;
 import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.home.dto.HomeResponseDto;
+import CodeSquad.IssueTracker.issue.IssueService;
+import CodeSquad.IssueTracker.issue.dto.IssueStatusUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -11,10 +13,17 @@ import org.springframework.web.bind.annotation.*;
 public class HomeController {
 
     private final HomeService homeService;
+    private final IssueService issueService;
 
     @GetMapping("/")
     public BaseResponseDto<HomeResponseDto> home(@RequestParam int page, @ModelAttribute IssueFilterCondition condition) {
         return BaseResponseDto.success("이슈목록을 성공적으로 불러왔습니다.",
                 homeService.getHomeData(page, condition));
+    }
+
+    @PatchMapping("toggleStatus")
+    public BaseResponseDto home(@RequestBody IssueStatusUpdateRequest condition) {
+        issueService.updateIssueOpenState(condition);
+        return BaseResponseDto.success("이슈 상태를 성공적으로 변경했습니다.", null);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -2,6 +2,7 @@ package CodeSquad.IssueTracker.issue;
 
 import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
+import CodeSquad.IssueTracker.issue.dto.IssueStatusUpdateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
 
 import java.util.List;
@@ -20,4 +21,6 @@ public interface IssueRepository {
     List<FilteredIssueDto> findIssuesByFilter(int page, IssueFilterCondition condition);
 
     int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterCondition condition);
+
+    void updateIsOpen(IssueStatusUpdateRequest condition);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -121,15 +121,6 @@ public class IssueService {
                 commentService.findCommentResponsesByIssueId(issue.getIssueId());
         response.setComments(comments);
 
-        Optional<User> byId = userService.findById(response.getIssue().getAuthorId());
-
-        if (byId.isPresent()) {
-            User author = byId.get();
-            response.setAuthorName(author.getNickName());
-            response.setAuthorProfileImage(author.getProfileImageUrl());
-        }
-
-
         return response;
     }
 
@@ -151,5 +142,9 @@ public class IssueService {
 
     public int countIssuesByOpenStatus(boolean isOpen, IssueFilterCondition condition) {
         return issueRepository.countFilteredIssuesByIsOpen(isOpen, condition);
+    }
+
+    public void updateIssueOpenState(IssueStatusUpdateRequest condition) {
+        issueRepository.updateIsOpen(condition);
     }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -3,6 +3,7 @@ package CodeSquad.IssueTracker.issue;
 
 import CodeSquad.IssueTracker.home.dto.IssueFilterCondition;
 import CodeSquad.IssueTracker.issue.dto.FilteredIssueDto;
+import CodeSquad.IssueTracker.issue.dto.IssueStatusUpdateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
 import CodeSquad.IssueTracker.milestone.dto.SummaryMilestoneDto;
 import CodeSquad.IssueTracker.user.dto.SummaryUserDto;
@@ -120,6 +121,23 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
         String finalSql = countSql + whereClause;
 
         return template.queryForObject(finalSql, queryBuilder.getParams(), Integer.class);
+    }
+
+    @Override
+    public void updateIsOpen(IssueStatusUpdateRequest condition) {
+        String sql = """
+                UPDATE issues SET is_open = :isOpen 
+                WHERE issue_id IN (:issueIds)
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        List<Long> issueIds = condition.getIssueIds();
+        params.addValue("issueIds", issueIds);
+
+        boolean isOpen = condition.isOpen();
+        params.addValue("isOpen", isOpen);
+
+        template.update(sql, params);
     }
 
     private RowMapper<Issue> issueRowMapper() {

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/dto/IssueStatusUpdateRequest.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/dto/IssueStatusUpdateRequest.java
@@ -1,11 +1,13 @@
 package CodeSquad.IssueTracker.issue.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class IssueStatusUpdateRequest {
     @JsonProperty("id")
     private List<Long> issueIds;

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/dto/IssueStatusUpdateRequest.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/dto/IssueStatusUpdateRequest.java
@@ -1,0 +1,15 @@
+package CodeSquad.IssueTracker.issue.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class IssueStatusUpdateRequest {
+    @JsonProperty("id")
+    private List<Long> issueIds;
+
+    @JsonProperty("isOpen")
+    private boolean isOpen;
+}

--- a/be/src/test/java/CodeSquad/IssueTracker/issue/issueServiceTest.java
+++ b/be/src/test/java/CodeSquad/IssueTracker/issue/issueServiceTest.java
@@ -1,0 +1,41 @@
+package CodeSquad.IssueTracker.issue;
+
+import CodeSquad.IssueTracker.issue.dto.IssueStatusUpdateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+public class issueServiceTest {
+
+    @Mock
+    IssueRepository issueRepository;
+
+    @InjectMocks
+    IssueService issueService;
+
+    @BeforeEach
+    void setup() {
+
+    }
+
+    @Test
+    @DisplayName("다중 이슈 ID (1, 2, 3)의 상태를 '닫힘'으로 변경한다")
+    void updateIssueStatusTest() {
+        // given
+        IssueStatusUpdateRequest condition = new IssueStatusUpdateRequest(List.of(1L, 2L, 3L), false);
+
+        // when
+        issueService.updateIssueOpenState(condition);
+
+        // then
+        Mockito.verify(issueRepository).updateIsOpen(condition);
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- close: #118

## 🎉 작업 사항
- 다중 이슈 상태 변경 기능 구현
- 서비스 레이어 테스트 코드 작성

## 📌 PR Point
### 다중 이슈 상태 변경
- 여러 개의 이슈를 선택하여 상태(열림 / 닫힘) 를 일괄 변경할 수 있도록 기능을 구현했습니다.
- UPDATE문과 IN절을 활용해 한 번의 쿼리로 다수의 이슈 상태를 변경합니다.

### 테스트 코드
- Service 계층의 updateIssueOpenState() 메서드가 Repository의 updateIsOpen()을 정상 호출하는지 테스트합니다.

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?
