### PR TITLE
[BE/MUD] - 코멘트 삭제 API 엔드포인트 구현

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'com.opencsv:opencsv:5.8'
 	implementation 'mysql:mysql-connector-java:8.0.33'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'com.h2database:h2'

--- a/be/src/main/java/CodeSquad/IssueTracker/comment/CommentController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/comment/CommentController.java
@@ -3,7 +3,7 @@ package CodeSquad.IssueTracker.comment;
 import CodeSquad.IssueTracker.comment.dto.CommentRequestDto;
 import CodeSquad.IssueTracker.comment.dto.CommentResponseDto;
 import CodeSquad.IssueTracker.comment.dto.CommentUpdateDto;
-import CodeSquad.IssueTracker.issue.dto.IssueCreateRequest;
+import CodeSquad.IssueTracker.global.dto.BaseResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,8 +13,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.util.List;
+
+import static CodeSquad.IssueTracker.global.message.SuccessMessage.COMMENT_DELETE_SUCCESS;
 
 @RestController
 @RequestMapping("/issues/{issueId}/comments")
@@ -42,5 +43,10 @@ public class CommentController {
         return commentService.update(commentId,request,files, Long.valueOf(authorId));
     }
 
+    @DeleteMapping("/{commentId}")
+    public BaseResponseDto<String> deleteComment(@PathVariable("commentId") Long commentId) {
+        commentService.deleteById(commentId);
+        return BaseResponseDto.success(COMMENT_DELETE_SUCCESS.getMessage(), null);
+    }
 
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum SuccessMessage {
     GITHUB_LOGIN_SUCCESS("Github 로그인을 성공했습니다"),
-    ISSUE_DETAIL_FETCH_SUCCESS("이슈 상세 정보를 성공적으로 조회했습니다.");
+    ISSUE_DETAIL_FETCH_SUCCESS("이슈 상세 정보를 성공적으로 조회했습니다."),
+    COMMENT_DELETE_SUCCESS("코멘트 삭제가 정상적으로 처리되었습니다.");
 
     private final String message;
 

--- a/be/src/main/java/CodeSquad/IssueTracker/jwt/filter/JwtAuthFilter.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/jwt/filter/JwtAuthFilter.java
@@ -46,10 +46,6 @@ public class JwtAuthFilter implements Filter {
         // ✅ 정적 리소스 및 공개 경로 우회
         if (isPermitAllPath(requestURI)) {
             log.info("[JWT Filter] ✅ 인증 예외 경로 우회: {}", requestURI);
-
-        // 특정 URL 경로는 필터를 적용하지 않도록 처리
-        if (requestURI.equals("/login") || requestURI.equals("/signup") || requestURI.equals("/oauth/callback/github")) {
-
             filterChain.doFilter(httpRequest, httpResponse);
             return;
         }
@@ -94,7 +90,8 @@ public class JwtAuthFilter implements Filter {
                 uri.endsWith(".svg") ||
                 uri.endsWith(".ico") ||
                 uri.startsWith("/assets/") ||
-                uri.startsWith("/static/");
+                uri.startsWith("/static/") ||
+                uri.startsWith("/oauth/callback/github");
     }
 
     private void writeJsonResponse(HttpServletResponse response, BaseResponseDto dto, HttpStatus status) throws IOException {


### PR DESCRIPTION
## 💡 관련 이슈
- close: #126 

## 🎉 작업 사항
- 코멘트 삭제 API 엔드포인트 구현

## 📌 PR Point
- DELETE /issues/{issueId}/comments/{commentId} 엔드포인트 구현
- commentService.deleteById 호출을 통해 댓글 삭제 처리

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?
