### PR TITLE
[BE/MUD] - 이슈 삭제 기능 구현

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/comment/CommentRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/comment/CommentRepository.java
@@ -12,4 +12,5 @@ public interface CommentRepository {
     void deleteById(Long commentId);
     void update(Long commentId, CommentUpdateDto updateDto);
     List<Comment> findByIssueId(Long issueId);
+    void deleteByIssueId(Long issueId);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/comment/CommentService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/comment/CommentService.java
@@ -4,18 +4,16 @@ import CodeSquad.IssueTracker.comment.dto.CommentRequestDto;
 import CodeSquad.IssueTracker.comment.dto.CommentResponseDto;
 import CodeSquad.IssueTracker.comment.dto.CommentUpdateDto;
 import CodeSquad.IssueTracker.global.exception.NotFoundException;
-import CodeSquad.IssueTracker.global.exception.UserNotFoundException;
 import CodeSquad.IssueTracker.user.User;
-import CodeSquad.IssueTracker.user.UserRepository;
 import CodeSquad.IssueTracker.user.UserService;
 import CodeSquad.IssueTracker.util.Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -81,5 +79,9 @@ public class CommentService {
                 .toList();
     }
 
+    @Transactional
+    public void  deleteAllByIssueId(Long issueId) {
+        commentRepository.deleteByIssueId(issueId);
+    }
 
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/comment/JdbcTemplatesCommentRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/comment/JdbcTemplatesCommentRepository.java
@@ -73,6 +73,13 @@ public class JdbcTemplatesCommentRepository implements CommentRepository {
         return template.query(sql, param, commentRowMapper());
     }
 
+    @Override
+    public void deleteByIssueId(Long issueId) {
+        String sql = "DELETE FROM comments WHERE issue_id = :issueId";
+        Map<String, Object> param = Map.of("issueId", issueId);
+        template.update(sql, param);
+    }
+
     private RowMapper<Comment> commentRowMapper(){
         return BeanPropertyRowMapper.newInstance(Comment.class);
     }

--- a/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum SuccessMessage {
     GITHUB_LOGIN_SUCCESS("Github 로그인을 성공했습니다"),
     ISSUE_DETAIL_FETCH_SUCCESS("이슈 상세 정보를 성공적으로 조회했습니다."),
-    COMMENT_DELETE_SUCCESS("코멘트 삭제가 정상적으로 처리되었습니다.");
+    COMMENT_DELETE_SUCCESS("코멘트 삭제가 정상적으로 처리되었습니다."),
+    ISSUE_DELETE_SUCCESS("이슈 삭제가 정상적으로 치리되었습니다.");
 
     private final String message;
 

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueController.java
@@ -1,7 +1,6 @@
 package CodeSquad.IssueTracker.issue;
 
 import CodeSquad.IssueTracker.global.dto.BaseResponseDto;
-import CodeSquad.IssueTracker.global.exception.NotFoundException;
 import CodeSquad.IssueTracker.issue.dto.IssueCreateRequest;
 import CodeSquad.IssueTracker.issue.dto.IssueDetailResponse;
 import CodeSquad.IssueTracker.issue.dto.IssueUpdateDto;
@@ -14,10 +13,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.Optional;
 
+import static CodeSquad.IssueTracker.global.message.SuccessMessage.ISSUE_DELETE_SUCCESS;
 import static CodeSquad.IssueTracker.global.message.SuccessMessage.ISSUE_DETAIL_FETCH_SUCCESS;
 
 @Slf4j
@@ -53,5 +51,10 @@ public class IssueController {
         return issueService.update(issueId, updateParam ,files);
     }
 
+    @DeleteMapping("/{issueId}")
+    public BaseResponseDto<String> deleteIssue(@PathVariable Long issueId) {
+        issueService.deleteIssue(issueId);
+        return BaseResponseDto.success(ISSUE_DELETE_SUCCESS.getMessage(), null);
+    }
 
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueRepository.java
@@ -23,4 +23,6 @@ public interface IssueRepository {
     int countFilteredIssuesByIsOpen(boolean isOpen, IssueFilterCondition condition);
 
     void updateIsOpen(IssueStatusUpdateRequest condition);
+
+    void deleteById(Long issueId);
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/IssueService.java
@@ -18,6 +18,7 @@ import CodeSquad.IssueTracker.user.UserService;
 import CodeSquad.IssueTracker.util.Uploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -154,6 +155,14 @@ public class IssueService {
 
     public void updateIssueOpenState(IssueStatusUpdateRequest condition) {
         issueRepository.updateIsOpen(condition);
+    }
+
+    @Transactional
+    public void deleteIssue(Long issueId) {
+        commentService.deleteAllByIssueId(issueId);
+        issueAssigneeService.unassignAssignee(issueId);
+        issueLabelService.unassignLabel(issueId);
+        issueRepository.deleteById(issueId);
     }
 }
 

--- a/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issue/JdbcTemplateIssueRepository.java
@@ -169,6 +169,13 @@ public class JdbcTemplateIssueRepository implements IssueRepository {
         template.update(sql, params);
     }
 
+    @Override
+    public void deleteById(Long issueId) {
+        String sql = "DELETE FROM issues WHERE issue_id = :issueId";
+        Map<String, Object> param = Map.of("issueId", issueId);
+        template.update(sql, param);
+    }
+
     private RowMapper<Issue> issueRowMapper() {
         return BeanPropertyRowMapper.newInstance(Issue.class);
     }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/IssueAssigneeService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/IssueAssigneeService.java
@@ -36,5 +36,8 @@ public class IssueAssigneeService {
         return issueAssigneeRepository.findAssigneeResponsesByIssueId(issueId);
     }
 
-
+    @Transactional
+    public void unassignAssignee(Long issueId) {
+        issueAssigneeRepository.deleteByIssueId(issueId);
+    }
 }

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/IssueLabelService.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/IssueLabelService.java
@@ -30,4 +30,9 @@ public class IssueLabelService {
     public List<IssueLabelResponse> findIssueLabelResponsesByIssueId(Long issueId) {
         return issueLabelRepository.returnedIssueLabelResponsesByIssueId(issueId);
     }
+
+    @Transactional
+    public void unassignLabel(Long issueId) {
+        issueLabelRepository.deleteByIssueId(issueId);
+    }
 }


### PR DESCRIPTION
 ## 💡 관련 이슈
- close: #128 

## 🎉 작업 사항
- 이슈 삭제 기능 구현

## 📌 PR Point
- 이슈 삭제 시 댓글, 라벨, 담당자 연관 관계 정리 후 이슈 삭제합니다.

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?

 