### PR TITLE
[BE/MUD] - 이슈 필터링 오류 해결

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/JdbcTemplateAssigneeRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueAssignee/JdbcTemplateAssigneeRepository.java
@@ -12,10 +12,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Repository
 public class JdbcTemplateAssigneeRepository implements IssueAssigneeRepository {
@@ -65,6 +62,10 @@ public class JdbcTemplateAssigneeRepository implements IssueAssigneeRepository {
     }
     @Override
     public Map<Long, List<SummaryUserDto>> findSummaryAssigneesByIssueIds(List<Long> issueIds) {
+        if (issueIds == null || issueIds.isEmpty()) {
+            return Collections.emptyMap();  // ✅ 리스트가 비면 SQL 실행 X
+        }
+
         String sql = """
         SELECT ia.issue_id, u.id, u.nick_name, u.profile_image_url
         FROM issue_assignee ia

--- a/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/issueLabel/JdbcTemplateIssueLabelRepository.java
@@ -12,10 +12,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Repository
 public class JdbcTemplateIssueLabelRepository implements IssueLabelRepository {
@@ -70,6 +67,10 @@ public class JdbcTemplateIssueLabelRepository implements IssueLabelRepository {
 
     @Override
     public Map<Long, List<SummaryLabelDto>> findSummaryLabelsByIssueIds(List<Long> issueIds) {
+        if (issueIds == null || issueIds.isEmpty()) {
+            return Collections.emptyMap();  // ✅ 리스트가 비면 SQL 실행 X
+        }
+
         String sql = """
         SELECT il.issue_id, l.label_id, l.name, l.color
         FROM issue_label il


### PR DESCRIPTION
 ## 💡 관련 이슈
- close: #

## 🎉 작업 사항
- issueIds가 빈 리스트일 때 SQL 문법 오류 방지

## 📌 PR Point
-  issueIds가 빈 리스트일 경우 IN () 구문으로 인한 SQL 오류 발생 문제 해결
- 빈 리스트일 때는 쿼리를 실행하지 않고 빈 결과를 바로 반환하도록 처리

## 📝 셀프체크리스트
- [X]  머지하려고 하는 브랜치가 올바른가?
- [X]  코딩컨벤션을 준수하는가?
- [X]  PR과 관련없는 변경사항이 없는가?

 