### PR TITLE
[BE/MUD] - 코멘트 관련 API 반환 형식 일치화

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/comment/CommentController.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/comment/CommentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.List;
 
-import static CodeSquad.IssueTracker.global.message.SuccessMessage.COMMENT_DELETE_SUCCESS;
+import static CodeSquad.IssueTracker.global.message.SuccessMessage.*;
 
 @RestController
 @RequestMapping("/issues/{issueId}/comments")
@@ -26,25 +26,27 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public CommentResponseDto writeComment(@RequestPart("data") @Validated CommentRequestDto request,
+    public BaseResponseDto<CommentResponseDto> writeComment(@RequestPart("data") @Validated CommentRequestDto request,
                                            @RequestPart(value = "files", required = false) List<MultipartFile> files,
                                            HttpServletRequest httpRequest) throws IOException {
         String authorId = httpRequest.getAttribute("id").toString();
         log.info("Writing comment with author id {}", authorId);
-        return commentService.createComment(request,files, Long.valueOf(authorId));
+        return BaseResponseDto.success(COMMENT_LIST_FETCH_SUCCESS.getMessage(),
+                commentService.createComment(request, files, Long.valueOf(authorId)));
     }
 
     @PatchMapping("/{commentId}")
-    public CommentResponseDto updateComment(@PathVariable("commentId") Long commentId,
+    public BaseResponseDto<CommentResponseDto> updateComment(@PathVariable("commentId") Long commentId,
                                             @RequestPart("data") CommentUpdateDto request,
                                             @RequestPart(value = "files", required = false) List<MultipartFile> files,
                                             HttpServletRequest httpRequest) throws IOException {
         String authorId = httpRequest.getAttribute("id").toString();
-        return commentService.update(commentId,request,files, Long.valueOf(authorId));
+        return BaseResponseDto.success(COMMENT_UPDATE_SUCCESS.getMessage(),
+                commentService.update(commentId, request, files, Long.valueOf(authorId)));
     }
 
     @DeleteMapping("/{commentId}")
-    public BaseResponseDto<String> deleteComment(@PathVariable("commentId") Long commentId) {
+    public BaseResponseDto deleteComment(@PathVariable("commentId") Long commentId) {
         commentService.deleteById(commentId);
         return BaseResponseDto.success(COMMENT_DELETE_SUCCESS.getMessage(), null);
     }

--- a/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/global/message/SuccessMessage.java
@@ -14,8 +14,6 @@ public enum SuccessMessage {
     ISSUE_UPDATE_SUCCESS("이슈 변경에 성공했습니다"),
     ISSUE_DELETE_SUCCESS("이슈 삭제가 정상적으로 치리되었습니다."),
 
-    COMMENT_DELETE_SUCCESS("코멘트 삭제가 정상적으로 처리되었습니다."),
-
     LABEL_DELETE_SUCCESS("라벨 삭제가 정상적으로 처리되었습니다."),
     LABEL_LIST_FETCH_SUCCESS("라벨 목록을 성공적으로 불러왔습니다."),
     LABEL_CREATE_SUCCESS("라벨 생성에 성공했습니다"),
@@ -24,7 +22,12 @@ public enum SuccessMessage {
     MILESTONE_LIST_FETCH_SUCCESS("마일스톤 목록을 성공적으로 불러왔습니다."),
     MILESTONE_CREATE_SUCCESS("마일스톤 생성에 성공했습니다"),
     MILESTONE_UPDATE_SUCCESS("마일스톤 변경에 성공했습니다"),
-    MILESTONE_DELETE_SUCCESS("마일스톤 삭제가 정상적으로 처리되었습니다.");
+    MILESTONE_DELETE_SUCCESS("마일스톤 삭제가 정상적으로 처리되었습니다."),
+
+    COMMENT_LIST_FETCH_SUCCESS("코멘트 목록을 성공적으로 불러왔습니다."),
+    COMMENT_CREATE_SUCCESS("코멘트 생성에 성공했습니다"),
+    COMMENT_UPDATE_SUCCESS("코멘트 변경에 성공했습니다"),
+    COMMENT_DELETE_SUCCESS("코멘트 삭제가 정상적으로 처리되었습니다.");
 
     private final String message;
 


### PR DESCRIPTION
- 코멘트 관련 API의 반환형식을 BaseResponseDto를 통해 반환하도록 구현