### PR TITLE
[BE/MUD] - JwtFilter에 /oauth-success 경로 허용

### DIFF
--- a/be/src/main/java/CodeSquad/IssueTracker/jwt/filter/JwtAuthFilter.java
+++ b/be/src/main/java/CodeSquad/IssueTracker/jwt/filter/JwtAuthFilter.java
@@ -91,7 +91,9 @@ public class JwtAuthFilter implements Filter {
                 uri.endsWith(".ico") ||
                 uri.startsWith("/assets/") ||
                 uri.startsWith("/static/") ||
-                uri.startsWith("/oauth/callback/github");
+                uri.startsWith("/oauth/callback/github") ||
+                uri.startsWith("/oauth-success");
+
     }
 
     private void writeJsonResponse(HttpServletResponse response, BaseResponseDto dto, HttpStatus status) throws IOException {


### PR DESCRIPTION

## 작업 내용
- OAuth 로그인 완료 후 프론트엔드 리디렉션을 위한 `/oauth-success` 경로를 JwtAuthFilter의 허용 목록에 추가